### PR TITLE
Refactor how reCaptcha is loaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,4 @@
 
 module.exports = {
   name: require('./package').name,
-
-  contentFor: function(type, config) {
-    var content = '';
-    if (type === 'body-footer') {
-      var src = config.gReCaptcha.jsUrl || 'https://www.google.com/recaptcha/api.js?render=explicit';
-      content = '<script type="text/javascript" src="'+src+'" async></script>';
-    }
-    return content;
-  }
 };


### PR DESCRIPTION
With these changes, an `onRender` callback can be passed in to the `g-recaptcha` component which will be triggered when the reCaptcha function is called.

For Example:

```
{{g-recaptcha onSuccess=(action "onReCaptchaResolved") onRender=(action "onReCaptchaRendered")}}
```

Since the reCaptcha is now dynamically being inserted when the component renders, we can remove the loop for checking to see if the reCaptcha has been loaded yet. These changes also remove the insertion of the script tag on app boot time.

This should fix https://github.com/algonauti/ember-g-recaptcha/issues/13 and https://github.com/algonauti/ember-g-recaptcha/issues/1