### PR TITLE
Fix test error from setup before component render

### DIFF
--- a/addon/components/g-recaptcha.js
+++ b/addon/components/g-recaptcha.js
@@ -71,9 +71,20 @@ export default Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
-    window.__ember_g_recaptcha_onload_callback = () => { this.renderReCaptcha(); };
+    let executed = false;
+    window.__ember_g_recaptcha_onload_callback = () => {
+      if (!executed) {
+        executed = true;
+        this.renderReCaptcha();
+      }
+    };
     let baseUrl = Configuration.jsUrl || 'https://www.google.com/recaptcha/api.js?render=explicit';
     this.appendScript(`${baseUrl}&onload=__ember_g_recaptcha_onload_callback`)
+  },
+
+  didDestroyElement() {
+    this._super(...arguments);
+    window.__ember_g_recaptcha_onload_callback = () => { };
   }
 
 });


### PR DESCRIPTION
-Fixes #48 

If an ember application is running several tests which all may render the ember-g-recaptcha component during the test. It's possible that the setup callback `__ember_g_recaptcha_onload_callback` gets called in a later test because the script loads only after the test it's rendered in has finished. This results in issues where a component may receive a callback to setup the component twice, resulting in console errors and test failures. Otherwise, it may try to setup after the component has already been destroyed during the test.

This pull request hopes to fix this issue by 
    1.) making the setup callback do nothing if `ember_g_recaptcha` has been destroyed
    2.) add an execute flag that ensures the setup is only called once